### PR TITLE
🚑 HOTFIX: 내부 Layout 좌우 패딩값 삭제, 컴포넌트별 패딩값 적용으로 복구(#60)

### DIFF
--- a/src/Components/Comment.jsx
+++ b/src/Components/Comment.jsx
@@ -37,7 +37,7 @@ export default function Comment(props) {
 }
 
 const Ldiv = styled.div`
-  margin: 0 0 16px 0;
+  margin: 0 12px 16px 16px;
 `;
 
 const Profile = styled.div`

--- a/src/Components/HomePost/HomePostLayout.jsx
+++ b/src/Components/HomePost/HomePostLayout.jsx
@@ -60,7 +60,7 @@ const HomePostLayout = () => {
 };
 
 const Layout = styled.article`
-  padding: 14px 0 60px 0;
+  padding: 14px 12px 60px 16px;
 `;
 
 const ImageLayout = styled.div`

--- a/src/Styles/Layout.jsx
+++ b/src/Styles/Layout.jsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 const LayoutStyle = css`
   margin: 0 auto;
-  padding: 48px 12px 73px 16px;
+  padding: 48px 0 73px;
   max-width: 390px;
   border: 1px solid var(--light-gray);
   min-height: 100%;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 마크업 & 스타일 : 
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [x] 버그 수정 : 내부 Layout 좌우 패딩값 삭제, 컴포넌트별 패딩값 적용으로 복구
- [ ] 도와주세요 : 
- [ ] 개발 환경 세팅 :

## 💬 전달사항
- 로컬에서 지우셨던 내부 컴포넌트 좌 12px 우 16px 패딩값들 다시 추가해주세요,,,!

## 💬 Issue Number
open : #
close : #60
