### PR TITLE
프로필 페이지, 공통 컴포넌트(User, Button)

### DIFF
--- a/src/Components/HomePost/HomePostLayout.jsx
+++ b/src/Components/HomePost/HomePostLayout.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 // import UserName from '../Components/common/UserName';
 import styled from 'styled-components';
+import URL from '../../Utils/URL';
 import User from '../common/User';
-import images from '../../test/images';
 import Profile from '../../Assets/profile-sm.png';
 import arrowRight from '../../Assets/icons/icon-arrow-right.svg';
 import arrowLeft from '../../Assets/icons/icon-arrow-left.svg';
@@ -11,8 +11,12 @@ import iconChat from '../../Assets/icons/icon-message-circle-1.svg';
 
 const HomePostLayout = (props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  // 임의로 이미지 생성
-  const pictures = [...images];
+  const post = props.post;
+  const userImg = post.author.image;
+  console.log(props.post);
+  const pictures = post.image.split(', ');
+  const createdAt =
+    post.createdAt.slice(0, 4) + '년 ' + post.createdAt.slice(5, 7) + '월 ' + post.createdAt.slice(8, 10) + '일 ';
 
   const handlePrev = () => {
     setCurrentIndex((prev) => (prev === 0 ? pictures.length - 1 : prev - 1));
@@ -22,39 +26,39 @@ const HomePostLayout = (props) => {
     setCurrentIndex((prev) => (prev === pictures.length - 1 ? 0 : prev + 1));
   };
 
-  // todo: props 받아주기
   return (
     <Layout>
-      <User userImg={Profile} username='애월읍 위니브' content='@ haron-lee' moreBtn={props.isEditable ? true : false}>
+      <User
+        accountname={post.author.accountname}
+        userImg={userImg || Profile}
+        username={post.author.username}
+        content={'@' + post.author.accountname}
+        moreBtn={props.isEditable ? true : false}
+      >
         애월읍 위니브
       </User>
       <ImageLayout>
         <ArrowButton onClick={handlePrev} bgImage={arrowLeft} left='16px'></ArrowButton>
-        <img src={pictures[currentIndex].src} alt='' />
+        <img src={URL + '/' + pictures[currentIndex]} alt='' />
         <ArrowButton onClick={handleNext} bgImage={arrowRight} right='16px'></ArrowButton>
         <IndicatorLayout>
-          {images.map((_, index) => {
-            return <Indicator key={index} onIndicator={index === currentIndex}></Indicator>;
+          {pictures.map((_, index) => {
+            return <Indicator key={index} indicator={index === currentIndex}></Indicator>;
           })}
         </IndicatorLayout>
       </ImageLayout>
       <IconLayout>
         <IconButton>
           <img src={iconHeart} alt='하트 아이콘' />
-          <span>58</span>
+          <span>{post.heartCount}</span>
         </IconButton>
         <IconButton>
           <img src={iconChat} alt='채팅 아이콘' />
-          <span>12</span>
+          <span>{post.commentCount}</span>
         </IconButton>
       </IconLayout>
-      <Content>
-        얼마나 품고 바이며, 인간이 생생하며, 능히 위하여 이상은 위하여서 있는가? 이 창공에 인도하겠다는 갑 사막이다.
-        동력은 힘차게 앞이 무한한 끓는 청춘의 지혜는 칼이다. 설산에서 목숨이 하였으며, 같은 착목한는 튼튼하며, 같이,
-        이상 아니다. 찾아다녀도, 가는 이상의 교향악이다. 인간의 피가 못하다 돋고, 가진 열락의 풀밭에 사막이다. 고동을
-        일월과 인생을 풍부하게 봄바람이다.
-      </Content>
-      <span>2023년 6월 14일</span>
+      <Content>{post.content}</Content>
+      <span>{createdAt}</span>
     </Layout>
   );
 };
@@ -101,7 +105,7 @@ const IndicatorLayout = styled.div`
 const Indicator = styled.div`
   width: 6px;
   height: 6px;
-  background-color: ${(props) => (props.onIndicator ? '#fff' : 'var(--gray)')};
+  background-color: ${(props) => (props.indicator ? '#fff' : 'var(--gray)')};
   border-radius: 50%;
 `;
 

--- a/src/Components/Profile/UserProfile.jsx
+++ b/src/Components/Profile/UserProfile.jsx
@@ -1,13 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
+import accountname from '../../Recoil/accountName/accountName';
 import ProfileImg from '../../Assets/profile-lg.png';
 import Chat from '../../Assets/icons/icon-message-circle-1.svg';
 import Share from '../../Assets/icons/icon-share.svg';
 import CommonButton from '../../Components/common/Button';
+import { useRecoilValue } from 'recoil';
 
 const UserProfile = (props) => {
-  const user = props.user;
-  console.log(user);
+  const user = props.user || props.author;
+  const name = useRecoilValue(accountname);
+  const [isFollowClicked, setIsFollowClicked] = useState(false);
+  const [isFollow, setIsFollow] = useState(user.isfollow);
+
+  const handleFollowButtonClick = (e) => {
+    setIsFollowClicked(!isFollowClicked);
+    if (e.target.textContent === '팔로우') {
+      e.target.textContent = '언팔로우';
+    } else {
+      e.target.textContent = '팔로우';
+    }
+  };
 
   return (
     <>
@@ -19,7 +32,6 @@ const UserProfile = (props) => {
               <strong>{user.followerCount}</strong>
               <p>followers</p>
             </FollowLayout>
-            {/* img태그로 해서 src를 가져와서 넣어야함 */}
             <ImgLayout>
               <img src={user.image ? user.image : ProfileImg} alt='사용자 프로필 사진' />
             </ImgLayout>
@@ -33,11 +45,20 @@ const UserProfile = (props) => {
             <p>{'@' + user.accountname}</p>
             <p>{user.intro}</p>
           </UserInfoLayout>
-          <IconLayout>
-            <ChatIconStyle />
-            <CommonButton width='120px'>팔로우</CommonButton>
-            <ShareIconStyle />
-          </IconLayout>
+          {user.accountname === name ? (
+            <IconLayout>
+              <CommonButton width='120px'>프로필 수정</CommonButton>
+              <CommonButton width='100px'>상품 등록</CommonButton>
+            </IconLayout>
+          ) : (
+            <IconLayout>
+              <ChatIconStyle />
+              <CommonButton width='120px' clicked={isFollowClicked} onClick={handleFollowButtonClick}>
+                팔로우
+              </CommonButton>
+              <ShareIconStyle />
+            </IconLayout>
+          )}
         </UserProfileLayout>
       )}
     </>
@@ -67,6 +88,8 @@ const ImgFollowLayout = styled.div`
 const ImgLayout = styled.div`
   width: 120px;
   height: 120px;
+  border-radius: 50%;
+  overflow: hidden;
 
   img {
     width: 100%;

--- a/src/Components/common/Button.jsx
+++ b/src/Components/common/Button.jsx
@@ -17,7 +17,6 @@ const BtnStyle = styled.button`
   background: ${(props) => props.bgColor || 'var(--primary)'};
   font-size: ${(props) => props.fontSize || '16px'};
   font-weight: ${(props) => props.fontWeight || '400'};
-  border: ${(props) => (props.border ? '1px solid var(--light-gray)' : 'none')};
   border-radius: ${(props) => props.borderRadius || '44px'};
   margin: ${(props) => props.margin || '0px'};
 
@@ -27,6 +26,14 @@ const BtnStyle = styled.button`
       background-color: var(--secondary);
       cursor: default;
     `};
+
+  ${(props) =>
+    props.clicked &&
+    css`
+      box-shadow: 0 0 0 1px var(--light-gray);
+      background-color: #fff;
+      color: var(--dark-gray);
+    `}
 `;
 
 export default Button;

--- a/src/Components/common/User.jsx
+++ b/src/Components/common/User.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import profileSm from '../../Assets/profile-sm.png';
 import more from '../../Assets/icons/s-icon-more-vertical.svg';
 import Button from './Button';
 
 const User = (props) => {
+  console.log(props);
   return (
     <UserLayout>
-      <UserImg src={props.UserImage || profileSm} alt={props.username} />
+      <Link to={`/profile/${props.accountname}`}>
+        <UserImg src={props.userImg || profileSm} alt={props.username} />
+      </Link>
       <UserContentsLayout>
         <div>
           <UserTitle>{props.username}</UserTitle>

--- a/src/Pages/Profile.jsx
+++ b/src/Pages/Profile.jsx
@@ -5,9 +5,14 @@ import HomePostLayout from '../Components/HomePost/HomePostLayout';
 import { Layout } from '../Styles/Layout';
 import Navbar from '../Components/common/Navbar';
 import UserInfoAPI from '../Utils/UserInfoAPI';
+import GetPostAPI from '../Utils/GetPostAPI';
 
 const Profile = () => {
   const userData = UserInfoAPI();
+
+  const postData = GetPostAPI();
+  console.log(postData);
+
   return (
     <Layout>
       <header>
@@ -15,7 +20,10 @@ const Profile = () => {
       </header>
       <main>
         <UserProfile user={userData} />
-        <HomePostLayout />
+        {postData &&
+          postData.map((post, index) => {
+            return <HomePostLayout key={index} post={post} />;
+          })}
       </main>
       <footer>
         <Navbar />

--- a/src/Utils/GetPostAPI.jsx
+++ b/src/Utils/GetPostAPI.jsx
@@ -1,34 +1,36 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import URL from './URL';
 import userToken from '../Recoil/userToken/userToken';
+import accountName from '../Recoil/accountName/accountName';
 import { useRecoilValue } from 'recoil';
 
-const UserInfoAPI = () => {
+const GetPostAPI = () => {
   const token = useRecoilValue(userToken);
-  const reqPath = `/user/myinfo`;
-  const [userData, setUserData] = useState({});
+  const accountname = useRecoilValue(accountName);
+  const reqPath = `/post/${accountname}/userpost`;
+  const [postData, setPostData] = useState([]);
 
-  const getUserData = async () => {
+  const getPostData = async () => {
     try {
       const response = await fetch(URL + reqPath, {
-        method: 'get',
+        method: 'GET',
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
 
       const data = await response.json();
-      setUserData(data.user);
+      setPostData(data.post);
     } catch (error) {
       console.error('API 응답에 문제가 있습니다.', error);
     }
   };
 
   useEffect(() => {
-    getUserData();
+    getPostData();
   }, []);
 
-  return userData;
+  return postData;
 };
 
-export default UserInfoAPI;
+export default GetPostAPI;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 :  내 게시물 불러오는 API 추가해서 프로필에 렌더링, User userimg 클릭시 Link로 이동
- [x] 마크업 & 스타일 : Button clicked css 추가, User userimg 이름 변경
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 도와주세요 : 
- [ ] 개발 환경 세팅 :

## 💬 전달사항
- 공통 컴포넌트 User안의 userImg 소문자로 변경
- 공통 컴포넌트 User의 userImg를 클릭시 사용자 페이지로 이동할 수 있게 Link 추가
- 공통 컴포넌트 Button이 clicked css 추가
- 프로필 페이지 내 게시물 불러오기 위한 GetPostAPI 추가
- 불러온 API로 렌더링 하기 위한 props 대응

## 💬 Issue Number
open : #15 #12 
close : #
