### PR TITLE
잘못된 접근시 로그인페이지, PC토스트 

### DIFF
--- a/src/Components/Landing/Landings.jsx
+++ b/src/Components/Landing/Landings.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { LayoutStyle } from '../../Styles/Layout';
@@ -14,21 +14,8 @@ import PCTripillow from './PCTripillow';
 const Landings = () => {
   const isPCScreen = useRecoilValue(isDesktop);
   const navigate = useNavigate();
-  const location = useLocation();
-  const [errorMSG, setErrorMSG] = useState('');
-
-  const handleErrorMSG = () => {
-    if (!!location.state) {
-      setErrorMSG(location.state);
-      setTimeout(() => {
-        setErrorMSG('');
-      }, 2000);
-    }
-  };
 
   useEffect(() => {
-    handleErrorMSG();
-
     if (isPCScreen) {
       const timer = setTimeout(() => {
         navigate('login');
@@ -36,7 +23,7 @@ const Landings = () => {
 
       return () => clearTimeout(timer);
     }
-  }, [location.state, isPCScreen]);
+  }, [isPCScreen]);
 
   if (isPCScreen) {
     return (
@@ -47,12 +34,6 @@ const Landings = () => {
   } else {
     return (
       <MobileLandingLayout>
-        {errorMSG && (
-          <AlertTop top='0px' newAnimation isError={!!location.state}>
-            {errorMSG}
-          </AlertTop>
-        )}
-
         <TripillowLayout>
           <img src={tripillowCharacter} alt='Tripillow 베게를 껴안고 작은 지구 위에 앉은 나무늘보 캐릭터' />
           <img src={Logo} alt='Tripillow' />

--- a/src/Components/Sign/LoginForm.jsx
+++ b/src/Components/Sign/LoginForm.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import styled, { keyframes, css } from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { LayoutStyle } from '../../Styles/Layout';
@@ -8,6 +8,8 @@ import Input from '../common/Input';
 import useLogin from '../../Hooks/Sign/useLogin';
 import isDesktop from '../../Recoil/isDesktop/isDesktop';
 import { formFadeIn } from '../../Styles/SignAnimation';
+import PCToast from '../common/Modal/PCToast';
+import AlertTop from '../common/Modal/AlertTop';
 
 import Kakao from '../../Assets/pc_kakao.png';
 import Google from '../../Assets/pc_google.png';
@@ -16,10 +18,35 @@ import FaceBook from '../../Assets/pc_facebook.png';
 const LoginForm = () => {
   const { handleFormSubmit, userInput, handleInputChange, errorMsg, handleError, userErrorMessage } = useLogin();
   const isPCScreen = useRecoilValue(isDesktop);
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const [warnMSG, setWarnMSG] = useState('');
+
+  const handleSnackbar = () => {
+    if (!!state) {
+      setWarnMSG(state);
+      setTimeout(() => {
+        setWarnMSG('');
+      }, 2500);
+    }
+  };
+
+  useEffect(() => {
+    handleSnackbar();
+
+    if (!!state) {
+      navigate('/login', { replace: true });
+    }
+  }, [state]);
 
   return (
     <Layout onSubmit={handleFormSubmit} $isPCScreen={isPCScreen}>
       <h1>로그인</h1>
+      {warnMSG && !isPCScreen && (
+        <AlertTop top='0px' newAnimation isError={warnMSG}>
+          {warnMSG}
+        </AlertTop>
+      )}
       <Input
         type='email'
         placeholder='아이디를 입력해주세요'
@@ -64,6 +91,7 @@ const LoginForm = () => {
           <img src={FaceBook} alt='facebook icon' />
         </LoginMethodLayout>
       )}
+      {warnMSG && isPCScreen && <PCToast warnMessage={warnMSG} />}
     </Layout>
   );
 };

--- a/src/Components/common/Modal/AlertTop.jsx
+++ b/src/Components/common/Modal/AlertTop.jsx
@@ -16,7 +16,8 @@ const AlertLayout = styled.div`
   background-color: ${(props) => (props.isError ? 'var(--error)' : 'var(--primary)')};
   color: white;
   box-shadow: 0 4px 5px rgba(0, 0, 0, 0.1);
-  animation: ${(props) => (props.newAnimation ? 'landingFadeIn 2s' : 'alertFadeIn 2s forwards')};
+  text-align: center;
+  animation: ${(props) => (props.newAnimation ? 'landingFadeIn 2s forwards' : 'alertFadeIn 2s forwards')};
 
   @keyframes alertFadeIn {
     0% {

--- a/src/Components/common/Modal/PCToast.jsx
+++ b/src/Components/common/Modal/PCToast.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const PCSnack = ({ warnMessage }) => {
+  return (
+    <SnackLayout>
+      <p>{warnMessage}</p>
+    </SnackLayout>
+  );
+};
+
+const SnackLayout = styled.div`
+  width: 150px;
+  padding: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  background-color: var(--error);
+  border-radius: 15px;
+  text-align: center;
+`;
+
+export default PCSnack;

--- a/src/Utils/ProtectRoute/ProtectRoute.jsx
+++ b/src/Utils/ProtectRoute/ProtectRoute.jsx
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ children }) => {
 
   useEffect(() => {
     if (!isUser) {
-      navigate('/', { state: errorMessage });
+      navigate('/login', { state: errorMessage });
     }
   }, []);
 


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
- [x] 마크업 & 스타일 : 
- [x] 리팩토링 : 
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 도와주세요 : 
- [ ] 개발 환경 세팅 :

## 💬 전달사항
- PC버전 토스트 UI 
- AlertTop animation 중 landingFadeIn forwards로 변경
- 잘못된 접근시 모바일 토스트를 랜딩페이지에서 로그인페이지에 나오게 변경
- PC 토스트 Login 컴포넌트에 추가
- 새로고침시 location에 state 비워주기 

## 💬 Issue Number
open : #
close : #266 
