### PR TITLE
프로필 페이지 재사용 함수 및 상태 분리, drilling 방지, 모달 새로고침시 안나오게 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3779,6 +3779,25 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.16.5",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
@@ -16127,6 +16146,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/Components/Profile/MobileUser.jsx
+++ b/src/Components/Profile/MobileUser.jsx
@@ -1,36 +1,28 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 import CommonButton from '../common/Button';
 import { UserProfileLayout, ImgLayout, IconBox, ShareIconStyle } from './UserStyle';
-
+import UseUserProfile from '../../Hooks/useUserProfile';
 import Chat from '../../Assets/icons/icon-message-circle-1.svg';
 import ProfileImg from '../../Assets/profile-lg.png';
 
-const MobileUser = ({
-  followerURL,
-  user,
-  userCount,
-  followingURL,
-  name,
-  handleChatClick,
-  followText,
-  handleFollowButtonClick,
-  handleCopy,
-}) => {
+const MobileUser = ({ user, handleCopy }) => {
   const navigate = useNavigate();
+  const { followerPath, followingPath, name, followText, handleFollowButtonClick, handleChatClick, followCount } =
+    UseUserProfile(user);
 
   return (
     <UserProfileLayout>
       <ImgFollowLayout>
-        <FollowLayout to={followerURL} state={user}>
-          <strong>{userCount}</strong>
+        <FollowLayout to={followerPath} state={user}>
+          <strong>{followCount}</strong>
           <p>pillowers</p>
         </FollowLayout>
         <ImgLayout>
           <img src={user.image ? user.image : ProfileImg} alt='사용자 프로필 사진' />
         </ImgLayout>
-        <FollowLayout to={followingURL} state={user} color='#767676'>
+        <FollowLayout to={followingPath} state={user} color='#767676'>
           <strong>{user.followingCount}</strong>
           <p>pillowings</p>
         </FollowLayout>
@@ -123,8 +115,6 @@ const IconLayout = styled.div`
     flex-shrink: 0;
   }
 `;
-
-// Icon Container
 
 const ChatIconStyle = styled.button`
   ${IconBox}

--- a/src/Components/Profile/PCUser.jsx
+++ b/src/Components/Profile/PCUser.jsx
@@ -1,23 +1,15 @@
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonButton from '../common/Button';
 import { UserProfileLayout, ImgLayout, ShareIconStyle } from './UserStyle';
-
+import UseUserProfile from '../../Hooks/useUserProfile';
 import ProfileImg from '../../Assets/profile-lg.png';
-import { Link, useNavigate } from 'react-router-dom';
 
-const PCUserProfile = ({
-  followerURL,
-  user,
-  userCount,
-  followingURL,
-  name,
-  handleChatClick,
-  followText,
-  handleFollowButtonClick,
-  handleCopy,
-}) => {
+const PCUserProfile = ({ user, handleCopy }) => {
   const navigate = useNavigate();
+  const { followerPath, followingPath, name, followText, handleFollowButtonClick, handleChatClick, followCount } =
+    UseUserProfile(user);
 
   return (
     <UserProfileLayout $pc>
@@ -27,7 +19,6 @@ const PCUserProfile = ({
       <UserInfo>
         <UserNameIcons>
           <h2>{user.username}</h2>
-          {/* buttons */}
           {user.accountname === name ? (
             <IconLayout>
               <CommonButton onClick={() => navigate('/profile/edit')} clicked width='91px' fontSize='var(--xs)'>
@@ -56,11 +47,11 @@ const PCUserProfile = ({
         </UserNameIcons>
         <CommonParagraph>{'@' + user.accountname}</CommonParagraph>
         <FollowsLayout>
-          <FollowLayout to={followerURL} state={user}>
-            <strong>{userCount}</strong>
+          <FollowLayout to={followerPath} state={user}>
+            <strong>{followCount}</strong>
             <p>pillowers</p>
           </FollowLayout>
-          <FollowLayout to={followingURL} state={user} color='var(--dark-gray)'>
+          <FollowLayout to={followingPath} state={user} color='var(--dark-gray)'>
             <strong>{user.followingCount}</strong>
             <p>pillowings</p>
           </FollowLayout>

--- a/src/Components/Profile/UserProfile.jsx
+++ b/src/Components/Profile/UserProfile.jsx
@@ -1,62 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
-import accountName from '../../Recoil/accountName/accountName';
-import MyInfoAPI from '../../Utils/MyInfoAPI';
-import FollowAPI from '../../Utils/FollowAPI';
-import UnFollowAPI from '../../Utils/UnFollowAPI';
 import AlertTop from '../common/Modal/AlertTop';
 import MobileUser from './MobileUser';
-import chatLists from '../../Mock/chatLists';
 import PCUser from './PCUser';
 import isDeskTop from '../../Recoil/isDesktop/isDesktop';
 
-const UserProfile = ({ followCount, setFollowCount, followerURL, followingURL, ...props }) => {
-  const navigate = useNavigate();
-  const user = props.user || props.author;
-  const follow = user?.isfollow;
-  const account = user?.accountname;
-  const userCount = user?.followerCount;
-  const username = props.user?.username;
-  const userImg = props.user?.image;
-  const name = useRecoilValue(accountName);
+const UserProfile = (props) => {
   const isPCScreen = useRecoilValue(isDeskTop);
-  const { getUserData } = MyInfoAPI();
-  const { followUser } = FollowAPI(account);
-  const { unFollowUser } = UnFollowAPI(account);
-  const [myData, setMyData] = useState({});
-  const [isFollow, setIsFollow] = useState(user?.isfollow);
-  const [followText, setFollowText] = useState(!follow ? '팔로우' : '언팔로우');
+  const user = props.user || props.author;
   const [isModal, setIsModal] = useState(false);
-  const [randomMessage, setRandomMessage] = useState('');
-
-  useEffect(() => {
-    const randomIndex = Math.floor(Math.random() * chatLists.length);
-    const selectedMessage = chatLists[randomIndex];
-    setRandomMessage(selectedMessage);
-  }, []);
-
-  useEffect(() => {
-    const fetchUserData = async () => {
-      const data = await getUserData();
-      setMyData(data);
-      setFollowCount(data.followingCount);
-    };
-    fetchUserData();
-  }, []);
-
-  useEffect(() => {
-    setIsFollow(user?.isfollow);
-  }, [follow]);
-
-  useEffect(() => {
-    if (isFollow) {
-      setFollowText('언팔로우');
-    } else if (!isFollow) {
-      setFollowText('팔로우');
-    }
-  }, [isFollow]);
 
   const handleCopyClipBoard = async (text) => {
     try {
@@ -67,29 +19,11 @@ const UserProfile = ({ followCount, setFollowCount, followerURL, followingURL, .
     }
   };
 
-  const handleCopy = async (text) => {
+  const handleCopy = async () => {
     isModal && setIsModal(false);
-    const modal = handleCopyClipBoard(window.location.href);
+    const modal = await handleCopyClipBoard(window.location.href);
     setIsModal(modal);
     setTimeout(() => setIsModal(false), 2300);
-  };
-
-  const handleFollowButtonClick = async (e) => {
-    if (isFollow) {
-      setIsFollow(false);
-      setFollowText('팔로우');
-      setFollowCount((prevCount) => prevCount - 1);
-      const data = await unFollowUser();
-    } else {
-      setIsFollow(true);
-      setFollowText('언팔로우');
-      setFollowCount((prevCount) => prevCount + 1);
-      const data = await followUser();
-    }
-  };
-
-  const handleChatClick = () => {
-    navigate(`/chat/${username}`, { state: { username, randomMessage, userImg } });
   };
 
   return (
@@ -103,41 +37,14 @@ const UserProfile = ({ followCount, setFollowCount, followerURL, followingURL, .
           )}
           <h1 className='a11y-hidden'>사용자 프로필</h1>
           {isPCScreen ? (
-            <PCUser
-              followerURL={followerURL}
-              user={user}
-              userCount={userCount}
-              followingURL={followingURL}
-              name={name}
-              handleChatClick={handleChatClick}
-              followText={followText}
-              handleFollowButtonClick={handleFollowButtonClick}
-              handleCopy={handleCopy}
-            />
+            <PCUser user={user} handleCopy={handleCopy} />
           ) : (
-            <MobileUser
-              followerURL={followerURL}
-              user={user}
-              userCount={userCount}
-              followingURL={followingURL}
-              name={name}
-              handleChatClick={handleChatClick}
-              followText={followText}
-              handleFollowButtonClick={handleFollowButtonClick}
-              handleCopy={handleCopy}
-            />
+            <MobileUser user={user} handleCopy={handleCopy} />
           )}
         </>
       )}
     </>
   );
 };
-
-const UserProfileLayout = styled.article`
-  margin: 0 auto;
-  padding: 30px 0 26px;
-  text-align: center;
-  background-color: #fff;
-`;
 
 export default UserProfile;

--- a/src/Hooks/useUserProfile.jsx
+++ b/src/Hooks/useUserProfile.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import FollowAPI from '../Utils/FollowAPI';
+import UnFollowAPI from '../Utils/UnFollowAPI';
+import chatLists from '../Mock/chatLists';
+import accountName from '../Recoil/accountName/accountName';
+import { followerURL, followingURL } from '../Recoil/followPath/followPath';
+
+const UseUserProfile = (props) => {
+  const user = props;
+  const navigate = useNavigate();
+  const follow = user?.isfollow;
+  const account = user?.accountname;
+  const username = user?.username;
+  const userImg = user?.image;
+  const name = useRecoilValue(accountName);
+  const followerPath = useRecoilValue(followerURL);
+  const followingPath = useRecoilValue(followingURL);
+  const [isFollow, setIsFollow] = useState(user?.isfollow);
+  const [followText, setFollowText] = useState(!follow ? '팔로우' : '언팔로우');
+  const [randomMessage, setRandomMessage] = useState('');
+  const [followCount, setFollowCount] = useState(user.followerCount);
+
+  const { followUser } = FollowAPI(account);
+  const { unFollowUser } = UnFollowAPI(account);
+
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * chatLists.length);
+    const selectedMessage = chatLists[randomIndex];
+    setRandomMessage(selectedMessage);
+  }, []);
+
+  useEffect(() => {
+    if (isFollow) {
+      setFollowText('언팔로우');
+    } else if (!isFollow) {
+      setFollowText('팔로우');
+    }
+  }, [isFollow]);
+
+  const handleFollowButtonClick = async (e) => {
+    if (isFollow) {
+      setIsFollow(false);
+      setFollowText('팔로우');
+      setFollowCount((prevCount) => prevCount - 1);
+      await unFollowUser();
+    } else {
+      setIsFollow(true);
+      setFollowText('언팔로우');
+      setFollowCount((prevCount) => prevCount + 1);
+      await followUser();
+    }
+  };
+
+  const handleChatClick = () => {
+    navigate(`/chat/${username}`, { state: { username, randomMessage, userImg } });
+  };
+  return {
+    followCount,
+    name,
+    handleChatClick,
+    followText,
+    handleFollowButtonClick,
+    followerPath,
+    followingPath,
+  };
+};
+
+export default UseUserProfile;

--- a/src/Pages/Profile/Profile.jsx
+++ b/src/Pages/Profile/Profile.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { LayoutStyle } from '../../Styles/Layout';
 import BasicHeader from '../../Components/common/Header/BasicHeader';
 import Navbar from '../../Components/common/Navbar';
@@ -11,7 +11,8 @@ import MyPillowings from '../../Components/Home/MyPillowings';
 import ProfileMain from '../../Components/Profile/ProfileMain';
 
 const Profile = () => {
-  const { state } = useLocation();
+  const navigate = useNavigate();
+  const { state, pathname } = useLocation();
   const isPCScreen = useRecoilValue(isDesktop);
   const [isDeleted, setIsDeleted] = useState(state?.isDeleted);
   const [isModified, setIsModified] = useState(state?.isModified);
@@ -25,6 +26,12 @@ const Profile = () => {
     }
   }, [isDeleted, isModified]);
 
+  useEffect(() => {
+    if (!!state) {
+      navigate(pathname, { replace: true });
+    }
+  }, [state]);
+
   return (
     <Layout $isPCScreen={isPCScreen}>
       {!isPCScreen && (
@@ -35,7 +42,7 @@ const Profile = () => {
           {isModified ? '수정되었습니다.' : '삭제되었습니다.'}
         </AlertTop>
       )}
-      <ProfileMain />
+      <ProfileMain setIsDeleted={setIsDeleted} setIsModified={setIsModified} />
       {isPCScreen || <Navbar />}
       {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>

--- a/src/Recoil/followPath/followPath.js
+++ b/src/Recoil/followPath/followPath.js
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+const followerURL = atom({
+  key: 'followerURL',
+  default: '',
+  effects_UNSTABLE: [persistAtom],
+});
+
+const followingURL = atom({
+  key: 'followingURL',
+  default: '',
+  effects_UNSTABLE: [persistAtom],
+});
+
+export { followerURL, followingURL };

--- a/src/Utils/GetPostAPI.jsx
+++ b/src/Utils/GetPostAPI.jsx
@@ -1,10 +1,8 @@
-import { useEffect, useState } from 'react';
 import URL from './URL';
 import userToken from '../Recoil/userToken/userToken';
 import { useRecoilValue } from 'recoil';
 
 const GetPostAPI = (accountName) => {
-  console.log('🚀  accountName:', accountName);
   const token = useRecoilValue(userToken);
 
   const getPostData = async () => {

--- a/src/Utils/UserInfoAPI.jsx
+++ b/src/Utils/UserInfoAPI.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import URL from './URL';
 import { useRecoilValue } from 'recoil';
 import userToken from '../Recoil/userToken/userToken';


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
- [ ] 마크업 & 스타일 : 
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 도와주세요 : 
- [ ] 개발 환경 세팅 :

## 💬 전달사항
- PCUser와 MobileUser에서 재사용되는 함수 및 상태 hook으로 분리
- follow, following 관련 이동경로 이름 drilling 발생으로 인해 recoil로 추가
- 분리된 함수 및 상태 정리
- 수정되었을 경우 modal 새로고침해도 나오는 현상 수정
  - state값이 있다면 현재 pathname으로 다시보내주면서 replace를 사용하여 새로고침이아니라 대체하게끔 함. 
  ```jsx
  useEffect(() => {
    if (!!state) {
      navigate(pathname, { replace: true });
    }
  }, [state]);
  ```


## ⚠️ 주의사항
- 현재 게시물 추가를 하면 좋아요의 위치는 그대로이고 게시물만 추가되면서 게시물은 추가되었지만 이전의 첫번째 좋아요 숫자가 추가된 게시물의 좋아요에 반영이 됨, 새로고침하면 정상적으로 돌아옴 
- 아래 그림은 사진있는 게시물에만 좋아요가 있는 상태임 하지만 게시물을 추가하니 gdgdgd게시물에 사진 게시물에 있던 좋아요가 들어간것이 보임. 게시물이 추가되었을 때 update가 필요
- 주의사항 내용은 수정 예정입니다.

<img width="668" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-15-Tripillow/assets/88657261/d9aa10ed-a35b-4b7b-9b6f-ef9c2dc2467b">


## 💬 Issue Number
open : #
close : #276 
