### PR TITLE
PC NavBar, Tab NavBar nav 태그로 수정, 이미지 alt 입력 및 useEffect 의존성 배열 메모이제이션

### DIFF
--- a/src/Components/PCNav/PCNavBar.jsx
+++ b/src/Components/PCNav/PCNavBar.jsx
@@ -72,7 +72,7 @@ const PCNavBar = (props) => {
                 }
               }}
             >
-              <Icon src={isClicked === el.name ? el.imgfill : el.img} />
+              <Icon src={isClicked === el.name ? el.imgfill : el.img} alt={el.name} />
               <IconInfo setColor={isClicked === el.name}>{el.name}</IconInfo>
             </Button>
           );
@@ -102,7 +102,7 @@ const PCNavBar = (props) => {
   );
 };
 
-const Layout = styled.div`
+const Layout = styled.nav`
   width: 335px;
   height: 100%;
   padding-top: 46px;

--- a/src/Components/TabNav/TabNavBar.jsx
+++ b/src/Components/TabNav/TabNavBar.jsx
@@ -51,7 +51,6 @@ const TabNavBar = (props) => {
     const icon = icons.find((el) => el.path === location.pathname);
     icon && setIsClicked(icon.name);
     setIsSearch(false);
-    console.log('useEffect 호출');
   }, [location, icons]);
 
 

--- a/src/Components/TabNav/TabNavBar.jsx
+++ b/src/Components/TabNav/TabNavBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { createPortal } from 'react-dom';
@@ -27,14 +27,18 @@ const TabNavBar = (props) => {
   const location = useLocation();
   const [isClicked, setIsClicked] = useState('');
   const [isSearch, setIsSearch] = useState(false);
-  const icons = [
-    { name: 'Search', img: search, imgfill: searchfill },
-    { name: 'Home', img: home, imgfill: homefill, path: '/home' },
-    { name: 'Chat', img: chat, imgfill: chatfill, path: '/chat' },
-    { name: 'Product', img: product, imgfill: productfill, path: '/product' },
-    { name: 'Add Post', img: post, imgfill: postfill, path: '/post' },
-    { name: 'Profile', img: profile, imgfill: profilefill, path: '/profile' },
-  ];
+  const icons = useMemo(
+    () => [
+      { name: 'Search', img: search, imgfill: searchfill },
+      { name: 'Home', img: home, imgfill: homefill, path: '/home' },
+      { name: 'Chat', img: chat, imgfill: chatfill, path: '/chat' },
+      { name: 'Product', img: product, imgfill: productfill, path: '/product' },
+      { name: 'Add Post', img: post, imgfill: postfill, path: '/post' },
+      { name: 'Profile', img: profile, imgfill: profilefill, path: '/profile' },
+    ],
+    [],
+  );
+
   const [isModalOn, setIsModalOn] = useState(false);
   const [isAlertModalOn, setIsAlertModalOn] = useState(false);
   const $Root = document.getElementById('root');
@@ -47,8 +51,9 @@ const TabNavBar = (props) => {
     const icon = icons.find((el) => el.path === location.pathname);
     icon && setIsClicked(icon.name);
     setIsSearch(false);
-    //eslint-disable-next-line
-  }, [location]);
+    console.log('useEffect 호출');
+  }, [location, icons]);
+
 
   return (
     <>
@@ -72,8 +77,7 @@ const TabNavBar = (props) => {
                 }
               }}
             >
-              <Icon src={isClicked === el.name ? el.imgfill : el.img} />
-              {/* <IconInfo setColor={isClicked === el.name}>{el.name}</IconInfo> */}
+              <Icon src={isClicked === el.name ? el.imgfill : el.img} alt={el.name} />
             </Button>
           );
         })}
@@ -102,7 +106,7 @@ const TabNavBar = (props) => {
   );
 };
 
-const Layout = styled.div`
+const Layout = styled.nav`
   width: 80px;
   height: 100%;
   padding-top: 46px;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
-  PC NavBar nav 태그로 수정, 이미지 alt 입력,
-  Tab NavBar nav 태그로 수정, 이미지 alt 입력, useMemo를 사용해서 icons 변수 메모이제이션
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 도와주세요 : icons 변수를 메모이제이션 할때 useMemo를 써도 괜찮은 것인지 궁금합니다.
icons = [
      { name: 'Search', img: search, imgfill: searchfill },
      { name: 'Home', img: home, imgfill: homefill, path: '/home' },
      { name: 'Chat', img: chat, imgfill: chatfill, path: '/chat' },
      { name: 'Product', img: product, imgfill: productfill, path: '/product' },
      { name: 'Add Post', img: post, imgfill: postfill, path: '/post' },
      { name: 'Profile', img: profile, imgfill: profilefill, path: '/profile' },
    ]
icons의 값이 함수가 아닌 값이라서 useMemo를 사용했습니다. 근데 useMemo를 자주 쓰면 성능에 안좋다는 말이 있어서 간단한 변수에 useMemo를 쓴느 것이 적합한 것인가라는 의문..
- [ ] 개발 환경 세팅 :

## 💬 전달사항

-

## 💬 Issue Number

open : #
close : #
