### PR TITLE
HOTFIX PostModification 무한렌더링 해결, MyPillowings 모바일에선 생성되지 않게 수정

### DIFF
--- a/src/Api/Post/PostDetailAPI.jsx
+++ b/src/Api/Post/PostDetailAPI.jsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 import URL from 'Api/URL';
 import userToken from 'Recoil/userToken/userToken';
@@ -5,7 +6,7 @@ import userToken from 'Recoil/userToken/userToken';
 const PostDetailAPI = (postId, updatePostInfo) => {
   const token = useRecoilValue(userToken);
 
-  const getPostDetail = async () => {
+  const getPostDetail = useCallback(async () => {
     try {
       const response = await fetch(`${URL}/post/${postId}`, {
         method: 'GET',
@@ -19,7 +20,7 @@ const PostDetailAPI = (postId, updatePostInfo) => {
     } catch (error) {
       console.error('API 응답에 실패하였습니다.', error);
     }
-  };
+  }, [postId, updatePostInfo, token]);
 
   return getPostDetail;
 };

--- a/src/Components/Home/MyPillowings.jsx
+++ b/src/Components/Home/MyPillowings.jsx
@@ -6,6 +6,7 @@ import FollowUser from 'Components/common/FollowUser';
 import UseFollowing from 'Hooks/useFollowing';
 
 const MyPillowings = (props) => {
+  console.log('mypillowings');
   const { followingData } = UseFollowing();
   const { getUserData } = MyInfoAPI();
   const [user, setUser] = useState();

--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -140,7 +140,7 @@ const Home = () => {
       </main>
       <TopButton />
       {isWideView || <Navbar />}
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>
   );
 };

--- a/src/Pages/Post/Post.jsx
+++ b/src/Pages/Post/Post.jsx
@@ -159,7 +159,7 @@ export default function Post() {
           </Button>
         )}
       </form>
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </PostLayout>
   );
 }

--- a/src/Pages/Post/PostDetail.jsx
+++ b/src/Pages/Post/PostDetail.jsx
@@ -106,7 +106,7 @@ const PostDetail = () => {
         </CommentLayout>
       </main>
       <PostComment setIsNewComment={setIsNewComment} postId={postId} userImg={myInfo.image}></PostComment>
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>
   );
 };

--- a/src/Pages/Post/PostModification.jsx
+++ b/src/Pages/Post/PostModification.jsx
@@ -236,7 +236,7 @@ const PostModification = () => {
           </>
         )}
       </form>
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </PostLayout>
   );
 };

--- a/src/Pages/Product/AddProduct.jsx
+++ b/src/Pages/Product/AddProduct.jsx
@@ -165,7 +165,7 @@ const AddProduct = (props) => {
         )}
       </AddProductContent>
       {isWideView || <Navbar />}
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>
   );
 };

--- a/src/Pages/Product/Product.jsx
+++ b/src/Pages/Product/Product.jsx
@@ -130,7 +130,7 @@ const Product = () => {
         ></CircleButton>
       </div>
       {isWideView || <Navbar />}
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </StyledLayout>
   );
 };

--- a/src/Pages/Product/ProductDetail.jsx
+++ b/src/Pages/Product/ProductDetail.jsx
@@ -183,7 +183,7 @@ const ProductDetail = () => {
               {productDetail?.link}
             </ProductContent>
           </main>
-          <MyPillowings $on={isPCScreen} />
+          {isPCScreen && <MyPillowings $on={isPCScreen} />}
         </Layout>
       )}
     </>

--- a/src/Pages/Product/ProductModification.jsx
+++ b/src/Pages/Product/ProductModification.jsx
@@ -154,7 +154,7 @@ const ProductModification = () => {
         )}
       </form>
       {isWideView || <Navbar />}
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>
   );
 };

--- a/src/Pages/Profile/Profile.jsx
+++ b/src/Pages/Profile/Profile.jsx
@@ -46,7 +46,7 @@ const Profile = () => {
       )}
       <ProfileMain setIsDeleted={setIsDeleted} setIsModified={setIsModified} />
       {isWideView || <Navbar />}
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </Layout>
   );
 };

--- a/src/Pages/Profile/UserProfileSetting.jsx
+++ b/src/Pages/Profile/UserProfileSetting.jsx
@@ -164,7 +164,7 @@ const UserProfileSetting = () => {
           </Button>
         )}
       </Form>
-      <MyPillowings $on={isPCScreen} />
+      {isPCScreen && <MyPillowings $on={isPCScreen} />}
     </UserSettingLayout>
   );
 };


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :  원래대로 MyPillowings 앞에 `isPCScreen` 조건을 붙여서 모바일에서 'display: none' 이 아닌 아예 생성되지 않게 수정
- [ ] 문서 수정 :
- [x] 버그 수정 : PostModification에서 무한렌더링 오류  getPostDetail을 useCallback에 넣었더니 해결되었습니다
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

## 💬 전달사항

-

## 💬 Issue Number

open : #
close : #
