### PR TITLE
!HOTFIX: 이미지 수정시 여러 이미지 추가 안되는 에러 수정

### DIFF
--- a/src/Api/Post/PostModifyAPI.jsx
+++ b/src/Api/Post/PostModifyAPI.jsx
@@ -2,8 +2,9 @@ import { useRecoilValue } from 'recoil';
 import userToken from 'Recoil/userToken/userToken';
 import URL from 'Api/URL';
 
-const PostModifyAPI = (postId, postInput, isLeftToggle) => {
+const PostModifyAPI = (postId, postInput, isLeftToggle, imgURL) => {
   const token = useRecoilValue(userToken);
+  const images = imgURL.join(', ');
 
   const postModify = async () => {
     try {
@@ -18,6 +19,7 @@ const PostModifyAPI = (postId, postInput, isLeftToggle) => {
           post: {
             ...postInput.post,
             content: isLeftToggle ? `[K]${postInput.post.content}` : `[G]${postInput.post.content}`,
+            image: images,
           },
         }),
       });

--- a/src/Pages/Post/PostModification.jsx
+++ b/src/Pages/Post/PostModification.jsx
@@ -38,7 +38,7 @@ const PostModification = () => {
   const [rightOn, setRightOn] = useState(false);
   const [imgChange, setImgChange] = useState(false);
   const getPostDetail = PostDetailAPI(postId, setOriginalPost);
-  const { postModify } = PostModifyAPI(postId, postInput, isLeftToggle);
+  const { postModify } = PostModifyAPI(postId, postInput, isLeftToggle, imgURL);
 
   useEffect(() => {
     const getDetail = async () => {
@@ -96,13 +96,6 @@ const PostModification = () => {
     }
 
     await uploadFile(e, (imageUrl) => {
-      setPostInput({
-        ...postInput,
-        post: {
-          ...postInput.post,
-          image: imageUrl,
-        },
-      });
       setImgURL((prev) => [...prev, imageUrl]);
     });
   };


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

## 💬 전달사항
- post와 동일하게 API 함수에 imgURL 넣어 준다음 join(', ') 하여 넣어줌
  - 이렇게 되면 postInput이 객체로 관리되지않아도 되기때문에 post처럼 따로 관리해도 괜찮을 듯 합니당
  - 에러 발견시 말씀해주세요

## 💬 Issue Number

open : #
close : #
